### PR TITLE
moved all the installs and deletes into single layer to reduce bloat …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ruby:alpine3.7
 MAINTAINER Adhityaa Chandrasekar <c.adhityaa@gmail.com>
 
-RUN apk add --no-cache --virtual build-deps build-base icu-dev icu-libs cmake git \
+RUN apk add --no-cache --virtual build-deps build-base icu-dev cmake \
+&& apk add --no-cache icu-libs git \
 && gem install gollum github-markdown \
-&& apk del cmake build-base build-deps icu-dev
+&& apk del build-deps
 
 # create a volume and
 WORKDIR /wiki

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
 FROM ruby:alpine3.7
 MAINTAINER Adhityaa Chandrasekar <c.adhityaa@gmail.com>
 
-# The default mirror (dl-cdn.alpinelinux.org) has issues sometimes for me
-# More mirrors available here: mirrors.alpinelinux.org
-RUN echo "https://mirror.csclub.uwaterloo.ca/alpine/v3.7/main" >/etc/apk/repositories && \
-    echo "https://mirror.csclub.uwaterloo.ca/alpine/v3.7/community" >>/etc/apk/repositories
-RUN apk update
-RUN apk add --no-cache --virtual build-deps build-base
-RUN apk add --no-cache icu-dev icu-libs
-RUN apk add --no-cache cmake
-RUN apk add --no-cache git
-
-RUN gem install gollum 
-RUN gem install github-markdown
-
-RUN apk del cmake build-base build-deps icu-dev
+RUN apk add --no-cache --virtual build-deps build-base icu-dev icu-libs cmake git \
+&& gem install gollum github-markdown \
+&& apk del cmake build-base build-deps icu-dev
 
 # create a volume and
 WORKDIR /wiki


### PR DESCRIPTION
…in final image

original image is 351MB (148MB compressed / docker hub reported size)
after moving everything into a single layer the image is 131MB local (and about 60MB compressed)

Even though packages are being deleted at the end of the install, they are already committed into a previous layer and will alway be present in the final image